### PR TITLE
Update fusion not ready log level

### DIFF
--- a/bno055/connectors/uart.py
+++ b/bno055/connectors/uart.py
@@ -35,6 +35,7 @@ import serial
 from rclpy.node import Node
 
 from bno055 import registers
+from bno055.error_handling.exceptions import BusOverRunException, TransmissionException
 from bno055.connectors.Connector import Connector
 
 
@@ -102,7 +103,7 @@ class UART(Connector):
             # Check for valid response length (the smallest (error) message has at least 2 bytes):
             if buf_in.__len__() < 2:
                 self.node.get_logger().error('Unexpected length of READ-request response: %s'
-                                             % buf_in.__len__())
+                                            % buf_in.__len__())
                 continue
 
             # Check for READ result (success or failure):
@@ -114,15 +115,14 @@ class UART(Connector):
                     continue
                 else:
                     self.node.get_logger().error('READ-request failed with error code %s'
-                                                 % hex(buf_in[1]))
+                                                % hex(buf_in[1]))
                     continue
 
             # Check for correct READ response header:
             if buf_in[0] != registers.COM_START_BYTE_RESP:
-                self.node.get_logger().error('Wrong READ-request response header %s'
-                                             % hex(buf_in[0]))
+                self.node.get_logger().error('Wrong READ-request response header %s' % hex(buf_in[0]))
                 continue
-
+            
             self.serialConnection.timeout = self.timeout
             try:
                 buf_in.extend(self.serialConnection.read(length))
@@ -132,14 +132,14 @@ class UART(Connector):
 
             if (buf_in.__len__()-2) != buf_in[1]:
                 self.node.get_logger().error('Payload length mismatch detected: '
-                                             + '  received=%s, awaited=%s'
-                                             % (buf_in.__len__()-2, buf_in[1]))
+                                            + '  received=%s, awaited=%s'
+                                            % (buf_in.__len__()-2, buf_in[1]))
                 continue
 
             # Check for correct READ-request response length
             if buf_in.__len__() != (2 + length):
                 self.node.get_logger().error('Incorrect READ-request response length: %s'
-                                             % (2 + length))
+                                            % (2 + length))
                 continue
 
             # remove the 0xBB:
@@ -151,8 +151,7 @@ class UART(Connector):
             # Return the received payload:
             return buf_in
 
-        raise Exception(f'Terminating, number of tries in serial read function \
-                        exceeded max_tries ({self.MAX_RETRIES}).')
+        raise Exception(f'Terminating, number of tries in serial read function exceeded max_tries ({self.MAX_RETRIES}).')
 
     def write(self, reg_addr, length, data: bytes):
         """
@@ -180,12 +179,10 @@ class UART(Connector):
                 continue
 
             if (buf_in.__len__() != 2) or (buf_in[1] != 0x01):
-                self.node.get_logger().error(f'Incorrect Bosh IMU device response. buf_in: \
-                                             {buf_in}')
+                self.node.get_logger().error(f'Incorrect Bosh IMU device response. buf_in: {buf_in}')
                 continue
 
             return True
 
-        self.node.get_logger().error(f'Number of tries in serial write function exceeded \
-                                     max_tries ({self.MAX_RETRIES}).')
+        self.node.get_logger().error(f'Number of tries in serial write function exceeded max_tries ({self.MAX_RETRIES}).')
         return False

--- a/bno055/params/NodeParameters.py
+++ b/bno055/params/NodeParameters.py
@@ -68,7 +68,7 @@ class NodeParameters:
         # UART First Bytes Timeout in seconds (time to wait for the first bytes of a message)
         # Should be smaller than the UART timeout to avoid unnecessary waiting when the sensor is
         # still computing the fusion and doesn't respond yet
-        node.declare_parameter('uart_first_bytes_timeout', value=0.01)
+        node.declare_parameter('uart_first_bytes_timeout', value=0.02)
         # tf frame id
         node.declare_parameter('frame_id', value='bno055')
         # Node timer frequency in Hz, defining how often sensor data is requested

--- a/bno055/params/bno055_params.yaml
+++ b/bno055/params/bno055_params.yaml
@@ -34,7 +34,7 @@ bno055:
     uart_port: "/dev/ttyUSB0"
     uart_baudrate: 115200
     uart_timeout: 0.1
-    uart_first_bytes_timeout: 0.01
+    uart_first_bytes_timeout: 0.02
     data_query_frequency: 100
     calib_status_frequency: 0.1
     frame_id: "bno055"


### PR DESCRIPTION
- Update frequently happening `Data fusion not ready, resend read request` log message's level to debug from error.
- Update default value for `uart_first_bytes_timeout` parameter.